### PR TITLE
Preliminary and experimental support for Game Boy Advance ROMs

### DIFF
--- a/REDasm.pro
+++ b/REDasm.pro
@@ -128,7 +128,8 @@ SOURCES += main.cpp\
     widgets/callgraphview/callgraphitem.cpp \
     widgets/graphview/graphviewmetrics.cpp \
     redasm/formats/xbe/xbe.cpp \
-    redasm/support/ordinals.cpp
+    redasm/support/ordinals.cpp \
+    redasm/formats/gba/gba.cpp
 
 HEADERS  += mainwindow.h \
     redasm/redasm.h \
@@ -246,7 +247,8 @@ HEADERS  += mainwindow.h \
     widgets/graphview/graphviewmetrics.h \
     redasm/formats/xbe/xbe.h \
     redasm/formats/xbe/xbe_header.h \
-    redasm/support/ordinals.h
+    redasm/support/ordinals.h \
+    redasm/formats/gba/gba.h
 
 FORMS    += mainwindow.ui \
     widgets/disassemblerview/disassemblerview.ui \

--- a/redasm/formats/gba/gba.cpp
+++ b/redasm/formats/gba/gba.cpp
@@ -1,0 +1,73 @@
+#include "gba.h"
+#include <cstring>
+
+#define GBAROM_OFFSET 0
+#define GBAROM_START_ADDR 0x8000000
+#define GBAROM_SIZE 0x2000000
+
+#define GBAEWRAM_OFFSET 0
+#define GBAEWRAM_START_ADDR 0x2000000
+#define GBAEW_SIZE 0x40000
+
+#define GBAIWRAM_OFFSET 0
+#define GBAIWRAM_START_ADDR 0x3000000
+#define GBAIW_SIZE 0x80000
+
+namespace REDasm {
+
+GbaRomFormat::GbaRomFormat(): FormatPluginT<GbaRomHeader>()
+{
+
+}
+
+const char *GbaRomFormat::name() const
+{
+    return "Game Boy Advance ROM";
+}
+
+u32 GbaRomFormat::bits() const
+{
+    return 32;
+}
+
+const char *GbaRomFormat::assembler() const
+{
+    return "arm"; //"arm7tdmi";
+}
+
+bool GbaRomFormat::load(u8* rawformat)
+{
+    GbaRomHeader* format = convert(rawformat);
+
+    if(!(format->fixed_val == 0x96)) // no signature/magic number is present in GBA ROMS
+        return false;
+
+    this->defineSegment("EWRAM", GBAEWRAM_OFFSET, GBAEWRAM_START_ADDR, GBAEW_SIZE, SegmentTypes::Bss);
+    this->defineSegment("IWRAM", GBAIWRAM_OFFSET, GBAIWRAM_START_ADDR, GBAIW_SIZE, SegmentTypes::Bss);
+    this->defineSegment("ROM", GBAROM_OFFSET, GBAROM_START_ADDR, GBAROM_SIZE, SegmentTypes::Code | SegmentTypes::Data);
+
+    this->defineEntryPoint(get_rom_ep(format->entry_point));
+    FormatPluginT<GbaRomHeader>::load(rawformat);
+    return true;
+}
+
+u32 GbaRomFormat::flags() const
+{
+    return FormatFlags::IgnoreUnexploredCode; // FIXME
+}
+
+u32 GbaRomFormat::get_rom_ep(u32 ep_branch)
+{
+  if ((ep_branch & 0x0A000000) != 0x0A000000) {
+    return 0;
+  }
+
+  u32 ep_val = (ep_branch & 0xFFFFFF);
+  if ((ep_val & 0x800000) != 0) {
+    ep_val |= ~0xFFFFFF;
+  }
+
+  return GBAROM_START_ADDR + 8 + (ep_val * 4); // Due to the pipeline nature of the ARM7TDMI processor, the PC value would be N+8 in ARM-STATE (N = address of the istruction)
+}
+
+}

--- a/redasm/formats/gba/gba.h
+++ b/redasm/formats/gba/gba.h
@@ -1,0 +1,52 @@
+#ifndef GBA_H
+#define GBA_H
+
+#include "../../plugins/plugins.h"
+
+#define GBAROM_HEADER_SIZE 192
+#define NINTENDO_LOGO_SIZE 156
+#define GAME_TITLE_SIZE 12
+#define GAME_CODE_SIZE 4
+#define MAKER_CODE_SIZE 2
+
+namespace REDasm {
+
+struct GbaRomHeader // From: http://problemkaputt.de/gbatek.htm#gbacartridgeheader
+{
+    u32 entry_point;
+    u8 nintendo_logo[NINTENDO_LOGO_SIZE];
+    u8 game_title[GAME_TITLE_SIZE];
+    u8 game_code[GAME_CODE_SIZE];
+    u8 maker_code[MAKER_CODE_SIZE];
+    u8 fixed_val;
+    u8 main_unit_code;
+    u8 device_type;
+    u8 reserved_area[7];
+    u8 software_version;
+    u8 header_checksum;
+    u8 reserved_area_2[2];
+    u32 ram_entry_point;
+    u8 boot_mode;
+    u8 slave_id;
+    u8 unused[26];
+    u32 joybus_entry_point;
+};
+
+class GbaRomFormat: public FormatPluginT<GbaRomHeader>
+{
+    public:
+        GbaRomFormat();
+        virtual const char* name() const;
+        virtual u32 bits() const;
+        virtual const char* assembler() const;
+        virtual bool load(u8 *rawformat);
+        virtual u32 flags() const;
+    private:
+        virtual u32 get_rom_ep(u32 ep_branch);
+};
+
+DECLARE_FORMAT_PLUGIN(GbaRomFormat, gbarom)
+
+}
+
+#endif // GBA_H

--- a/redasm/plugins/plugins.cpp
+++ b/redasm/plugins/plugins.cpp
@@ -11,6 +11,7 @@
 #include FORMAT_PLUGIN(psxexe)
 #include FORMAT_PLUGIN(dex)
 #include FORMAT_PLUGIN(xbe)
+#include FORMAT_PLUGIN(gba)
 
 /* *** Assemblers *** */
 #include ASSEMBLER_PLUGIN(x86)
@@ -39,6 +40,7 @@ void init(const std::string& searchpath)
     REGISTER_FORMAT_PLUGIN(psxexe);
     REGISTER_FORMAT_PLUGIN(dex);
     REGISTER_FORMAT_PLUGIN(xbe);
+    REGISTER_FORMAT_PLUGIN(gbarom);
     REGISTER_FORMAT_PLUGIN(binary); // Always last choice
 
     REGISTER_ASSEMBLER_PLUGIN(x86_16);


### PR DESCRIPTION
This PR adds preliminary support for Game Boy Advance ROMs.
The GBA format is now understood and I was able to get the disasm of the first function.

FormatFlags::IgnoreUnexploredCode is currently needed to avoid a crash.

I plan to enhance the binary type detection adding the header CRC check. Please DO NOT use the nintendo logo array in the header as a way of roms detection: this is not present in some roms (Action Replay and bootlegs for example).


Thanks