### PR TITLE
deploy with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ cd REDasm
 qmake && make
 ```
 
+## Compiling from Source with docker
+```
+cd docker
+# create a docker image
+./build.sh image
+# build REDasm
+./build.sh nightly
+# remove docker image
+./build rm
+```
+after compiling the binary is in the folder release
+
 ## Nightly Builds
 Nightly builds are produced by AppVeyor (Windows) and TravisCI (Linux) and they can be downloaded from [here](https://github.com/REDasmOrg/REDasm-Builds).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04
+
+MAINTAINER bongartz@klimlive.de
+
+RUN apt update \
+; apt install -y \
+  qt5-qmake \
+  qt5-default \
+  qtwebengine5-dev \
+  libqt5webenginewidgets5 \
+  cmake \
+  g++ \
+  git
+
+COPY ./nightly-entrypoint.sh /
+
+ENTRYPOINT ["/nightly-entrypoint.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+build_dir=${PWD}/release
+
+image=redasm-nightly
+nightly=redasm_nightly
+
+imageService() {
+    docker build -t ${image} .
+}
+
+nightlyService() {
+    mkdir -p ${build_dir}
+    docker run --rm -v ${build_dir}:/deploy --name ${nightly} ${image} .
+}
+
+rmService() {
+    docker rmi ${image}
+}
+
+case "$1" in
+    image)   imageService ;;
+    nightly)    nightlyService ;;
+    rm)    rmService ;;
+    *) echo "usage: $0"
+       echo "  image:   builds docker image"
+       echo "  stable:  currently not implemented"
+       echo "  nightly: runs a container to build a redasm as nightly version"
+       echo "  rm:      removes docker image"
+       exit 1
+       ;;
+esac

--- a/docker/nightly-entrypoint.sh
+++ b/docker/nightly-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+git clone --branch=master https://github.com/REDasmOrg/REDasm.git /redasm
+# git checkout -qf $VERSION
+pushd redasm
+git submodule update --init --recursive
+mkdir -p build
+pushd build
+qmake CONFIG+=release ..
+make
+cp REDasm /deploy
+popd


### PR DESCRIPTION
A docker folder has been added. It contains a Dockerfile to build REDasm and a helper script `build.sh` .
How to use the script can be found in the readme.
```
usage: ./build.sh
  image:   builds docker image
  stable:  currently not implemented
  nightly: runs a container to build a redasm as nightly version
  rm:      removes docker image

```