### PR TITLE
bugFix: GraphView, null renderer cause various crash

### DIFF
--- a/widgets/graphview/disassemblergraphview/disassemblergraphview.cpp
+++ b/widgets/graphview/disassemblergraphview/disassemblergraphview.cpp
@@ -193,8 +193,6 @@ void DisassemblerGraphView::selectedItemChangedEvent()
 
     if(selecteditem)
         m_disassembleractions->setCurrentRenderer(static_cast<DisassemblerBlockItem*>(selecteditem)->renderer());
-    else
-        m_disassembleractions->setCurrentRenderer(nullptr);
 
     GraphView::selectedItemChangedEvent();
 }

--- a/widgets/graphview/graphview.cpp
+++ b/widgets/graphview/graphview.cpp
@@ -45,8 +45,11 @@ void GraphView::setSelectedBlock(GraphViewItem *item)
         if(gvi != item)
             continue;
 
+        bool changed = (m_selecteditem != item);
         m_selecteditem = item;
         this->focusSelectedBlock();
+        if (changed)
+            this->selectedItemChangedEvent();
         break;
     }
 }


### PR DESCRIPTION
**GraphView: setSelectBlock, trigger selectedItemChangeEvent**

When switching between disassembler view to graph view is necessary to trigger the selectedItemChanged so that setCurrentRenderer is initialized correctly.

If you don't do this, many disassembler actions fails causing app crash.

**DisassemblerGraphView: selectedItemChangedEvent null renderer**

It's better to not reset the current renderer, cause many function inside DisassemblerActions fails or need a null check on the renderer.

Infact It's not possible to clear the current selection, so I think it makes sense to keep the previous valid renderer.

Thanks for your time.
Have a nice day.
